### PR TITLE
Breadcrumb dark mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@woven-planet/lakefront",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@woven-planet/lakefront",
-      "version": "6.0.2",
+      "version": "6.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@woven-planet/lakefront",
   "description": "React UI Components",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/woven-planet/lakefront",

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -36,7 +36,6 @@ export interface BreadcrumbProps {
 const Breadcrumb: FC<BreadcrumbProps> = ({ routes, Link = ReactRouterDomLink }) => {
 
     return (
-        <ThemeProvider theme={theme}>
             <BreadCrumbStyle>
                 <nav>
                     {routes.map((route, index) => {
@@ -58,7 +57,6 @@ const Breadcrumb: FC<BreadcrumbProps> = ({ routes, Link = ReactRouterDomLink }) 
                     })}
                 </nav>
             </BreadCrumbStyle>
-        </ThemeProvider>
     );
 };
 

--- a/src/components/Breadcrumb/__tests__/Breadcrumb.tests.jsx
+++ b/src/components/Breadcrumb/__tests__/Breadcrumb.tests.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { render } from '@testing-library/react';
 import Breadcrumb from '../Breadcrumb';
 import { BrowserRouter } from 'react-router-dom';
+import { renderWithTheme } from '../../../lib/testing';
 
 describe('<Breadcrumb />', () => {
     it('renders a single route just fine', () => {
@@ -12,7 +12,7 @@ describe('<Breadcrumb />', () => {
             }
         ];
 
-        const { container } = render(<BrowserRouter><Breadcrumb routes={routes} /></BrowserRouter>);
+        const { container } = renderWithTheme(<BrowserRouter><Breadcrumb routes={routes} /></BrowserRouter>);
         expect(container.querySelectorAll('nav')[0]).toHaveTextContent('Page');
     });
 
@@ -28,7 +28,7 @@ describe('<Breadcrumb />', () => {
             }
         ];
 
-        const { container } = render(<BrowserRouter><Breadcrumb routes={routes} /></BrowserRouter>);
+        const { container } = renderWithTheme(<BrowserRouter><Breadcrumb routes={routes} /></BrowserRouter>);
         expect(container.querySelectorAll('nav')[0]).toHaveTextContent('Sub Page');
     });
 });

--- a/src/components/Breadcrumb/__tests__/BreadcrumbHeader.tests.jsx
+++ b/src/components/Breadcrumb/__tests__/BreadcrumbHeader.tests.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { render } from '@testing-library/react';
 import BreadcrumbHeader from '../BreadcrumbHeader';
 import { BrowserRouter } from 'react-router-dom';
+import { renderWithTheme } from '../../../lib/testing';
 
 describe('<BreadcrumbHeader />', () => {
     it('renders a single route just fine', () => {
@@ -12,7 +12,7 @@ describe('<BreadcrumbHeader />', () => {
             }
         ];
 
-        const { container } = render(<BrowserRouter><BreadcrumbHeader routes={routes}
+        const { container } = renderWithTheme(<BrowserRouter><BreadcrumbHeader routes={routes}
             standalone={true} /></BrowserRouter>);
         expect(container.querySelectorAll('nav')[0]).toHaveTextContent('Page');
         expect(container.querySelectorAll('div')[0]).toHaveStyle('border-bottom: 1px solid');
@@ -27,7 +27,7 @@ describe('<BreadcrumbHeader />', () => {
             }
         ];
 
-        const { container } = render(<BrowserRouter><BreadcrumbHeader routes={routes}
+        const { container } = renderWithTheme(<BrowserRouter><BreadcrumbHeader routes={routes}
             standalone={true} hideRoutes={true} /></BrowserRouter>);
         expect(container.querySelectorAll('nav')[0]).not.toHaveTextContent('Page');
     });
@@ -40,7 +40,7 @@ describe('<BreadcrumbHeader />', () => {
             }
         ];
 
-        const { container } = render(<BrowserRouter><BreadcrumbHeader routes={routes}
+        const { container } = renderWithTheme(<BrowserRouter><BreadcrumbHeader routes={routes}
             standalone={true} hideRoutes={true} ><h2>Test Header</h2></BreadcrumbHeader></BrowserRouter>);
         expect(container).toHaveTextContent('Test Header');
     });

--- a/src/components/Breadcrumb/breadcrumbStyles.ts
+++ b/src/components/Breadcrumb/breadcrumbStyles.ts
@@ -2,22 +2,21 @@ import styled from '@emotion/styled';
 
 export const BreadCrumbStyle = styled.div(({ theme }) => ({
     display: 'grid',
-    backgroundcolor: theme?.colors?.white,
     'nav': {
         alignSelf: 'center',
         display: 'flex',
     },
     'a': {
-        color: theme?.colors?.pavement,
+        color: theme.foregrounds.secondary,
         textDecoration: 'none',
         '&:hover': {
-            color: theme?.colors?.storm,
+            color: theme.foregrounds.primary,
         }
     }
 }));
 
 export const Current = styled.span(({ theme }) => ({
-    color: theme?.colors?.storm,
+    color: theme.foregrounds.primary,
     fontWeight: 500
 }));
 
@@ -32,8 +31,8 @@ export const Container = styled.div<any>(({ theme, standalone }) => ({
     ...((standalone) && {
         padding: '0 3.5rem',
         borderBottom: '1px solid',
-        borderBottomColor: theme?.colors?.mercury,
-        backgroundColor: theme?.colors?.white
+        borderBottomColor: theme.borderColors.primary,
+        backgroundColor: theme.backgrounds.primary
     })
 }));
 


### PR DESCRIPTION
This PR creates a dark mode version of Breadcrumb. Screenshots below:
<img width="905" height="663" alt="image" src="https://github.com/user-attachments/assets/fd8cdff2-f90f-46b4-8e1f-1dbc571a9bae" />
<img width="883" height="636" alt="image" src="https://github.com/user-attachments/assets/34cea49b-1f4f-4156-b636-d56b5df15e34" />


### Lakefront PR Checklist

- [ ]  Created new components following the [contributing guide](#https://github.com/woven-planet/lakefront/blob/main/CONTRIBUTING.md#adding-new-components).
- [ ]  Exported any new components in the `src/index.ts`.
- [ ]  Updated the main [README table](https://github.com/woven-planet/lakefront#how-to-add-components-to-this-table).
- [ ]  Ensure version numbers were bumped properly.
- [ ]  Imported SVGs with relative path, if applicable.
- [ ]  Removed any irrelevant commit messages from merge commit.
- [ ]  Deleted branch after merge.
