### PR TITLE
Fix multi select initial value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@woven-planet/lakefront",
-  "version": "6.13.0",
+  "version": "6.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@woven-planet/lakefront",
-      "version": "6.13.0",
+      "version": "6.13.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@woven-planet/lakefront",
-  "version": "6.12.0",
+  "version": "6.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@woven-planet/lakefront",
-      "version": "6.12.0",
+      "version": "6.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@woven-planet/lakefront",
   "description": "React UI Components",
-  "version": "6.12.0",
+  "version": "6.13.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/woven-planet/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@woven-planet/lakefront",
   "description": "React UI Components",
-  "version": "6.13.0",
+  "version": "6.13.1",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/woven-planet/lakefront",

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -58,7 +58,14 @@ export interface SelectProps {
      * This is the default text before an option is selected.
      */
     placeholder?: string;
-    value: any[] | string | number;
+    /**
+     * The value of the select component (if you want to control externally).
+     */
+    value?: any[] | string | number;
+    /**
+     * A value to initially set the multi-select component to.
+     */
+    multiDefaultValue?: SelectOption[];
 }
 
 
@@ -66,19 +73,19 @@ export interface SelectProps {
  *  The select component is used to render a dropdown with options. The user can set a selected option by default.
  *  The isSearchable property allows user to find the value from the options available.
  */
-const Select: FC<SelectProps> = ({ options, className, isMulti, ...rest }) => {
+const Select: FC<SelectProps> = ({ options, className, isMulti, value = '', ...rest }) => {
 
 
     return (
         <SelectStyles>
-            <SelectStyledComponent className={className} multiple={isMulti} {...rest}>
+            <SelectStyledComponent className={className} multiple={isMulti} value={value} {...rest}>
                 {options.map((option) => (
                     <option key={`${option.label}${option.value ?? ''}`} value={option.value}>
                         {option.label}
                     </option>
                 ))}
             </SelectStyledComponent>
-            <SelectOverlay {...rest} options={options} isMulti={isMulti}/>
+            <SelectOverlay {...rest} value={value} options={options} isMulti={isMulti}/>
         </SelectStyles>
     );
 };

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -73,19 +73,19 @@ export interface SelectProps {
  *  The select component is used to render a dropdown with options. The user can set a selected option by default.
  *  The isSearchable property allows user to find the value from the options available.
  */
-const Select: FC<SelectProps> = ({ options, className, isMulti, value = '', ...rest }) => {
+const Select: FC<SelectProps> = ({ options, className, isMulti, ...rest }) => {
 
 
     return (
         <SelectStyles>
-            <SelectStyledComponent className={className} multiple={isMulti} value={value} {...rest}>
+            <SelectStyledComponent className={className} multiple={isMulti} {...rest}>
                 {options.map((option) => (
                     <option key={`${option.label}${option.value ?? ''}`} value={option.value}>
                         {option.label}
                     </option>
                 ))}
             </SelectStyledComponent>
-            <SelectOverlay {...rest} value={value} options={options} isMulti={isMulti}/>
+            <SelectOverlay {...rest} options={options} isMulti={isMulti}/>
         </SelectStyles>
     );
 };

--- a/src/components/Select/SelectOverlay.tsx
+++ b/src/components/Select/SelectOverlay.tsx
@@ -3,8 +3,8 @@ import { SelectProps } from './Select';
 import Select from 'react-select';
 import { SELECT_OVERLAY_STYLES } from './selectStyles';
 import theme from 'src/styles/theme';
-const SelectOverlay: FC<SelectProps> = ({ isSearchable = false, disabled, id, options, onChange, value, isMulti, ...rest }) => {
-    const [multiValues, setMultiValues] = useState([]);
+const SelectOverlay: FC<SelectProps> = ({ isSearchable = false, disabled, id, options, onChange, value, isMulti, multiDefaultValue = [], ...rest }) => {
+    const [multiValues, setMultiValues] = useState(multiDefaultValue);
 
     const { currentValue, defaultValue, selectId } = useMemo(
         () => {

--- a/src/stories/Select/Select.stories.tsx
+++ b/src/stories/Select/Select.stories.tsx
@@ -47,7 +47,7 @@ const Template: StoryFn<SelectProps & ComponentPropsWithoutRef<'div'>> = (args) 
             <section style={{ display: 'inline-flex', height: '150px' }}>
                 <SelectComponent options={args.options} value={value} onChange={handleOnChange} id={args.id}
                     isSearchable={args.isSearchable} disabled={args.disabled} className={args.className}
-                    autoFocus={args.autoFocus} isMulti={args.isMulti} />
+                    autoFocus={args.autoFocus} isMulti={args.isMulti} multiDefaultValue={args.multiDefaultValue} />
             </section>
         </>
     );
@@ -65,4 +65,11 @@ MultiSelect.args = {
     options: [{ label: 'Km', value: 'metric' }, { label: 'Mi', value: 'imperial' }, {label: 'Made up system', value: 'made up'}],
     value: '',
     isMulti: true
+};
+
+export const MultiSelectWithDefaultValues = Template.bind({});
+MultiSelectWithDefaultValues.args = {
+  options: [{ label: 'Km', value: 'metric' }, { label: 'Mi', value: 'imperial' }, {label: 'Made up system', value: 'made up'}],
+  multiDefaultValue: [{ label: 'Mi', value: 'imperial' }, {label: 'Made up system', value: 'made up'}],
+  isMulti: true
 };


### PR DESCRIPTION
This PR adds the ability to set default values on a `Select` component when using `isMulti` mode.

<img width="333" height="100" alt="image" src="https://github.com/user-attachments/assets/fdc46f6b-6b2a-41fb-8cd0-7d6745490907" />

### Lakefront PR Checklist

- [x]  Ensure version numbers were bumped properly.
- [x]  Removed any irrelevant commit messages from merge commit.
- [x]  Deleted branch after merge.
