### PR TITLE
Enable async Select component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@woven-planet/lakefront",
-  "version": "6.13.1",
+  "version": "6.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@woven-planet/lakefront",
-      "version": "6.13.1",
+      "version": "6.13.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@woven-planet/lakefront",
-  "version": "6.14.1",
+  "version": "6.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@woven-planet/lakefront",
-      "version": "6.14.1",
+      "version": "6.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@woven-planet/lakefront",
-  "version": "6.13.2",
+  "version": "6.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@woven-planet/lakefront",
-      "version": "6.13.2",
+      "version": "6.13.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.10.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@woven-planet/lakefront",
   "description": "React UI Components",
-  "version": "6.13.2",
+  "version": "6.13.3",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/woven-planet/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@woven-planet/lakefront",
   "description": "React UI Components",
-  "version": "6.13.1",
+  "version": "6.13.2",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/woven-planet/lakefront",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@woven-planet/lakefront",
   "description": "React UI Components",
-  "version": "6.14.1",
+  "version": "6.15.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "homepage": "https://github.com/woven-planet/lakefront",

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -2,19 +2,22 @@ import { FC } from 'react';
 import { SelectStyles, SelectStyledComponent } from './selectStyles';
 import SelectOverlay from './SelectOverlay';
 import { GetStyles, GroupBase } from 'react-select/dist/declarations/src/types';
+import { AsyncProps as ReactAsyncSelectProps } from 'react-select/async';
+import { Props as ReactSelectProps } from 'react-select';
+import { extractNativeSelectProps } from 'src/components/Select/selectUtil';
 
 export interface SelectOption {
     value: string | number | undefined;
     label: string;
 }
 
-export interface SelectProps {
+export interface SelectProps extends ReactSelectProps {
     /**
      * This is to set the options of the dropdown.
      */
     options: SelectOption[];
     /**
-     * This is called when an dropdown change event.
+     * This is called on a dropdown change event.
      */
     onChange(event: any): void;
     /**
@@ -66,6 +69,10 @@ export interface SelectProps {
      * A value to initially set the multi-select component to.
      */
     multiDefaultValue?: SelectOption[];
+    /**
+     * Enable async select component
+     */
+    asyncConfig?: ReactAsyncSelectProps<SelectOption, boolean, GroupBase<SelectOption>>;
 }
 
 
@@ -73,12 +80,13 @@ export interface SelectProps {
  *  The select component is used to render a dropdown with options. The user can set a selected option by default.
  *  The isSearchable property allows user to find the value from the options available.
  */
-const Select: FC<SelectProps> = ({ options, className, isMulti, ...rest }) => {
-
+const Select: FC<SelectProps> = (props) => {
+    const { options, className, isMulti, ...rest }  = props;
+    const nativeSelectProps = extractNativeSelectProps(props);
 
     return (
         <SelectStyles>
-            <SelectStyledComponent className={className} multiple={isMulti} {...rest}>
+            <SelectStyledComponent {...nativeSelectProps}>
                 {options.map((option) => (
                     <option key={`${option.label}${option.value ?? ''}`} value={option.value}>
                         {option.label}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -72,7 +72,7 @@ export interface SelectProps extends ReactSelectProps {
     /**
      * Enable async select component
      */
-    asyncConfig?: ReactAsyncSelectProps<SelectOption, boolean, GroupBase<SelectOption>>;
+    asyncConfig?: Partial<ReactAsyncSelectProps<SelectOption, boolean, GroupBase<SelectOption>>>;
 }
 
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -70,7 +70,9 @@ export interface SelectProps extends ReactSelectProps {
      */
     multiDefaultValue?: SelectOption[];
     /**
-     * Enable async select component
+     * Enable async select component.
+     * Note: Some optional props that are applicable to both normal and async Select variants may
+     * need to be explicitly defined in asyncConfig to work properly (e.g. noOptionsMessage, placeholder).
      */
     asyncConfig?: Partial<ReactAsyncSelectProps<SelectOption, boolean, GroupBase<SelectOption>>>;
 }

--- a/src/components/Select/SelectOverlay.tsx
+++ b/src/components/Select/SelectOverlay.tsx
@@ -5,7 +5,19 @@ import AsyncSelect from 'react-select/async';
 import { SELECT_OVERLAY_STYLES } from './selectStyles';
 import theme from 'src/styles/theme';
 
-const SelectOverlay: FC<SelectProps> = ({ isSearchable = false, disabled, id, options, onChange, value, isMulti, multiDefaultValue = [], asyncConfig, ...rest }) => {
+const SelectOverlay: FC<SelectProps> = ({
+    isSearchable = false,
+    disabled,
+    id,
+    options,
+    onChange,
+    value,
+    isMulti,
+    multiDefaultValue = [],
+    asyncConfig,
+    styles,
+    ...rest
+}) => {
     const [multiValues, setMultiValues] = useState(multiDefaultValue);
 
     const { currentValue, defaultValue, selectId } = useMemo(
@@ -45,7 +57,7 @@ const SelectOverlay: FC<SelectProps> = ({ isSearchable = false, disabled, id, op
         value: currentValue,
         options: options,
         onChange: handleChange,
-        styles: SELECT_OVERLAY_STYLES,
+        styles: { ...SELECT_OVERLAY_STYLES, ...styles },
         theme: (defaultTheme: any) => ({
             ...defaultTheme,
             colors: {

--- a/src/components/Select/SelectOverlay.tsx
+++ b/src/components/Select/SelectOverlay.tsx
@@ -1,9 +1,11 @@
 import { FC, useMemo, useState } from 'react';
 import { SelectProps } from './Select';
 import Select from 'react-select';
+import AsyncSelect from 'react-select/async';
 import { SELECT_OVERLAY_STYLES } from './selectStyles';
 import theme from 'src/styles/theme';
-const SelectOverlay: FC<SelectProps> = ({ isSearchable = false, disabled, id, options, onChange, value, isMulti, multiDefaultValue = [], ...rest }) => {
+
+const SelectOverlay: FC<SelectProps> = ({ isSearchable = false, disabled, id, options, onChange, value, isMulti, multiDefaultValue = [], asyncConfig, ...rest }) => {
     const [multiValues, setMultiValues] = useState(multiDefaultValue);
 
     const { currentValue, defaultValue, selectId } = useMemo(
@@ -36,27 +38,40 @@ const SelectOverlay: FC<SelectProps> = ({ isSearchable = false, disabled, id, op
         }
     };
 
+    const commonProps = {
+        isDisabled: disabled,
+        id: selectId,
+        defaultValue: defaultValue,
+        value: currentValue,
+        options: options,
+        onChange: handleChange,
+        styles: SELECT_OVERLAY_STYLES,
+        theme: (defaultTheme: any) => ({
+            ...defaultTheme,
+            colors: {
+                ...defaultTheme.colors,
+                ...theme.colors,
+                primary: theme.colors.white,
+                primary25: disabled ? theme.colors.white : theme.colors.mercury
+            }
+        }),
+        isSearchable: isSearchable,
+        isMulti: isMulti
+    };
+
+    if (asyncConfig) {
+        return (
+            <AsyncSelect
+              {...commonProps}
+              {...asyncConfig}
+            />
+        );
+    }
+
     return (
         <Select
-            isDisabled={disabled}
-            id={selectId}
-            defaultValue={defaultValue}
-            value={currentValue}
-            options={options}
-            onChange={handleChange}
-            styles={SELECT_OVERLAY_STYLES}
-            theme={(defaultTheme) => ({
-                ...defaultTheme,
-                colors: {
-                    ...defaultTheme.colors,
-                    ...theme.colors,
-                    primary: theme.colors.white,
-                    primary25: disabled ? theme.colors.white : theme.colors.mercury
-                }
-            })}
-            isSearchable={isSearchable}
-            isMulti={isMulti}
-            {...rest}
+          {...commonProps}
+          {...rest}
         />
     );
 };

--- a/src/components/Select/selectUtil.ts
+++ b/src/components/Select/selectUtil.ts
@@ -1,0 +1,42 @@
+import { SelectProps } from 'src/components/Select/Select';
+
+/**
+ * Utility to extract native select props from SelectProps
+ * @param props
+ */
+export const extractNativeSelectProps = (props: SelectProps) => {
+  const {
+    id,
+    disabled,
+    autoFocus,
+    name,
+    required,
+    value,
+    defaultValue,
+    onChange,
+    onBlur,
+    placeholder,
+    form,
+    tabIndex,
+    className,
+    isMulti
+  } = props;
+
+  return {
+    id,
+    disabled,
+    autoFocus,
+    name,
+    required,
+    value,
+    // Filter defaultValue to be compatible
+    defaultValue: typeof defaultValue === 'string' || typeof defaultValue === 'number' || Array.isArray(defaultValue) ? defaultValue : undefined,
+    multiple: isMulti,
+    onChange,
+    onBlur,
+    placeholder,
+    form,
+    tabIndex,
+    className,
+  };
+}

--- a/src/stories/Select/Select.stories.tsx
+++ b/src/stories/Select/Select.stories.tsx
@@ -1,8 +1,9 @@
 import { ComponentPropsWithoutRef, useState } from 'react';
 import { Meta, StoryFn } from '@storybook/react-webpack5';
-import SelectComponent, { SelectProps } from 'src/components/Select';
+import SelectComponent, { SELECT_OVERLAY_STYLES, SelectProps } from 'src/components/Select';
 import DocBlock from '.storybook/DocBlock';
 import { emerald } from 'src/styles/lakefrontColors';
+import { SelectOption } from 'src/components/Select/Select';
 
 export default {
     title: 'Lakefront/Select',
@@ -45,9 +46,18 @@ const Template: StoryFn<SelectProps & ComponentPropsWithoutRef<'div'>> = (args) 
                 {areValuesSelected() && value.length > 0 && args.isMulti && `The selected values are: ${value.map(v => ` ${v}`)}`}
             </div>
             <section style={{ display: 'inline-flex', height: '150px' }}>
-                <SelectComponent options={args.options} value={value} onChange={handleOnChange} id={args.id}
-                    isSearchable={args.isSearchable} disabled={args.disabled} className={args.className}
-                    autoFocus={args.autoFocus} isMulti={args.isMulti} multiDefaultValue={args.multiDefaultValue} />
+                <SelectComponent
+                  value={value}
+                  onChange={handleOnChange}
+                  styles={{
+                    ...SELECT_OVERLAY_STYLES,
+                    control: (baseStyles, state) => ({
+                      ...SELECT_OVERLAY_STYLES.control(baseStyles, state),
+                      minWidth: 300
+                    })
+                  }}
+                  {...args}
+                />
             </section>
         </>
     );
@@ -72,4 +82,31 @@ MultiSelectWithDefaultValues.args = {
   options: [{ label: 'Km', value: 'metric' }, { label: 'Mi', value: 'imperial' }, {label: 'Made up system', value: 'made up'}],
   multiDefaultValue: [{ label: 'Mi', value: 'imperial' }, {label: 'Made up system', value: 'made up'}],
   isMulti: true
+};
+
+export const AsyncSelect = Template.bind({});
+AsyncSelect.args = {
+  options: [],
+  multiDefaultValue: [],
+  isMulti: true,
+  openMenuOnClick: false,
+  isSearchable: true,
+  asyncConfig: {
+    placeholder: 'Start typing to fetch options.',
+    noOptionsMessage: ({ inputValue }) => inputValue.length < 3 ? 'Input at least 3 characters.' : 'No matching options. Try typing "Some"',
+    loadOptions: (inputValue: string, callback: (options: SelectOption[]) => void) => {
+      if (inputValue.length < 3) {
+        callback([]);
+        return;
+      }
+      // Simulate an async call to fetch options based on the input value
+      setTimeout(() => {
+        // Here you would typically make an API call to fetch options
+        const filteredOptions = [{ label: 'Some', value: 'some' }, {label: 'Something', value: 'something'}, {label: 'Some things', value: 'some_things'}].filter((option) =>
+          option.label.toLowerCase().includes(inputValue.toLowerCase())
+        );
+        callback(filteredOptions);
+      }, 1000); // Simulate network delay
+    }
+  }
 };


### PR DESCRIPTION
This PR is for allowing async use of the Select component, allowing the `asyncConfig` prop to be passed to fetch menu options. Type updates were also applied to better indicate how the `Select` component can be used.

### Lakefront PR Checklist

- [ ]  Ensure version numbers were bumped properly.
- [ ]  Removed any irrelevant commit messages from merge commit.
- [ ]  Deleted branch after merge.
